### PR TITLE
Don't throw on `ms('0 days')`

### DIFF
--- a/src/ms.macro.js
+++ b/src/ms.macro.js
@@ -16,7 +16,7 @@ export default createMacro(({ babel: { types: t }, references: { default: paths 
     const value = getValue(parentPath);
     if (value) {
       const newValue = ms(value);
-      if (typeof newValue === 'number') {
+      if (typeof newValue === 'number' && !Number.isNaN(newValue)) {
         parentPath.replaceWith(t.numericLiteral(newValue));
       } else {
         const { line } = parentPath.node.loc.start;

--- a/src/ms.macro.js
+++ b/src/ms.macro.js
@@ -16,7 +16,7 @@ export default createMacro(({ babel: { types: t }, references: { default: paths 
     const value = getValue(parentPath);
     if (value) {
       const newValue = ms(value);
-      if (newValue) {
+      if (typeof newValue === 'number') {
         parentPath.replaceWith(t.numericLiteral(newValue));
       } else {
         const { line } = parentPath.node.loc.start;

--- a/src/ms.macro.test.js
+++ b/src/ms.macro.test.js
@@ -11,6 +11,7 @@ const run = code => transform(code, {
 
 {
   const expected = stripIndent`
+    const ZERO_DAYS = 0;
     const ONE_DAY = 86400000;
     const TWO_DAYS = 172800000;
   `;
@@ -18,6 +19,7 @@ const run = code => transform(code, {
   test('CallExpression', (t) => {
     const input = stripIndent`
       import ms from './ms.macro';
+      const ZERO_DAYS = ms('0 days');
       const ONE_DAY = ms('1 day');
       const TWO_DAYS = ms('2 days');
     `;
@@ -28,6 +30,7 @@ const run = code => transform(code, {
   test('TaggedTemplateExpression', (t) => {
     const input = stripIndent`
       import ms from './ms.macro';
+      const ZERO_DAYS = ms\`0 days\`;
       const ONE_DAY = ms\`1 day\`;
       const TWO_DAYS = ms\`2 days\`;
     `;


### PR DESCRIPTION
This fixes a bug where `ms('0 days')` or anything that returns `0` would throw with `"Invalid input given to ms.macro at line {}"`.